### PR TITLE
chore: use general indexing types for symmetric tensor powers

### DIFF
--- a/Mathlib/LinearAlgebra/TensorPower/Symmetric.lean
+++ b/Mathlib/LinearAlgebra/TensorPower/Symmetric.lean
@@ -9,10 +9,11 @@ import Mathlib.LinearAlgebra.TensorPower.Basic
 /-!
 # Symmetric tensor power of a semimodule over a commutative semiring
 
-We define the `n`th symmetric tensor power of `M` as the `TensorPower` quotiented by the relation
-that the `tprod` of `n` elements is equal to the `tprod` of the same elements permuted by a
-permutation of `Fin n`. We denote this space by `Sym[R]^n M`, and the canonical multilinear map
-from `M ^ n` to `Sym[R]^n M` by `⨂ₛ[R] i, f i`.
+We define the `ι`-indexed symmetric tensor power of `M` as the `PiTensorProduct` quotiented by
+the relation that the `tprod` of `ι` elements is equal to the `tprod` of the same elements permuted
+by a permutation of `ι`. We denote this space by `Sym[R] ι M`, and the canonical multilinear map
+from `ι → M` to `Sym[R] ι M` by `⨂ₛ[R] i, f i`. We also reserve the notation `Sym[R]^n M` for the
+`n`th symmetric tensor power of `M`, which is the symmetric tensor power indexed by `Fin n`.
 
 ## Main definitions:
 
@@ -34,39 +35,46 @@ universe u v
 
 open TensorProduct Equiv
 
-variable (R : Type u) [CommSemiring R] (M : Type v) [AddCommMonoid M] [Module R M] (n : ℕ)
+variable (R ι : Type u) [CommSemiring R] (M : Type v) [AddCommMonoid M] [Module R M] (s : ι → M)
 
-/-- The relation on the `n`ᵗʰ tensor power of `M` that two tensors are equal if they are related by
-a permutation of `Fin n`. -/
-inductive SymmetricPower.Rel : ⨂[R]^n M → ⨂[R]^n M → Prop
-  | perm : (e : Perm (Fin n)) → (f : Fin n → M) → Rel (⨂ₜ[R] i, f i) (⨂ₜ[R] i, f (e i))
+/-- The relation on the `ι`-indexed tensor power of `M` where two tensors are equal
+if they are related by a permutation of `ι`. -/
+inductive SymmetricPower.Rel : (⨂[R] _, M) → (⨂[R] _, M) → Prop
+  | perm : (e : Perm ι) → (f : ι → M) → Rel (⨂ₜ[R] i, f i) (⨂ₜ[R] i, f (e i))
 
-/-- The symmetric tensor power of a semimodule `M` over a commutative semiring `R`
-is the quotient of the `n`ᵗʰ tensor power by the relation that two tensors are equal
-if they are related by a permutation of `Fin n`. -/
+/-- The `ι`-indexed symmetric tensor power of a semimodule `M` over a commutative semiring `R`
+is the quotient of the `ι`-indexed tensor power of `M` by the relation that two tensors are equal
+if they are related by a permutation of `ι`. -/
 def SymmetricPower : Type max u v :=
-  (addConGen (SymmetricPower.Rel R M n)).Quotient
+  (addConGen (SymmetricPower.Rel R ι M)).Quotient
 
-@[inherit_doc] scoped[TensorProduct] notation:max "Sym[" R "]^" n:arg M:arg => SymmetricPower R M n
+@[inherit_doc]
+scoped[TensorProduct] notation:max "Sym[" R "] " ι:arg M:arg => SymmetricPower R ι M
+
+/-- The `n`th symmetric tensor power of a semimodule `M` over a commutative semiring `R` -/
+scoped[TensorProduct] notation:max "Sym[" R "]^" n:arg M:arg => Sym[R] (Fin n) M
 
 namespace SymmetricPower
 
-instance : AddCommMonoid (Sym[R]^n M) := AddCon.addCommMonoid _
+instance : AddCommMonoid (Sym[R] ι M) := AddCon.addCommMonoid _
 
-instance (R : Type u) [CommRing R] (M : Type v) [AddCommGroup M] [Module R M] (n : ℕ) :
-    AddCommGroup (Sym[R]^n M) := AddCon.addCommGroup _
+instance (R : Type u) [CommRing R] (M : Type v) [AddCommGroup M] [Module R M] :
+    AddCommGroup (Sym[R] ι M) := AddCon.addCommGroup _
 
-variable {R M n} in
-lemma smul (r : R) (x y : ⨂[R]^n M) (h : addConGen (Rel R M n) x y) :
-    addConGen (Rel R M n) (r • x) (r • y) := by
+variable {R ι M} in
+lemma smul (r : R) (x y : ⨂[R] _, M) (h : addConGen (Rel R ι M) x y) :
+    addConGen (Rel R ι M) (r • x) (r • y) := by
   induction h with
   | of x y h => cases h with
-    | perm e f => cases n with
-      | zero => convert (addConGen (Rel R M 0)).refl _
-      | succ n =>
-          convert AddConGen.Rel.of _ _ (Rel.perm (R := R) e (Function.update f 0 (r • f 0)))
-          · rw [MultilinearMap.map_update_smul, Function.update_eq_self]
-          · simp_rw [Function.update_apply_equiv_apply, MultilinearMap.map_update_smul,
+    | perm e f =>
+      apply isEmpty_or_nonempty ι |>.elim <;> intro h
+      · convert addConGen (Rel R ι M) |>.refl _
+      · let i := Nonempty.some h
+        classical
+        convert AddConGen.Rel.of _ _ <| SymmetricPower.Rel.perm (R := R) (ι := ι) e
+          <| Function.update f i (r • f i)
+        · rw [MultilinearMap.map_update_smul, Function.update_eq_self]
+        · simp_rw [Function.update_apply_equiv_apply, MultilinearMap.map_update_smul,
               ← Function.update_comp_equiv, Function.update_eq_self]; rfl
   | refl => exact AddCon.refl _ _
   | symm => apply AddCon.symm; assumption
@@ -75,15 +83,15 @@ lemma smul (r : R) (x y : ⨂[R]^n M) (h : addConGen (Rel R M n) x y) :
 
 variable {R} in
 /-- Scalar multiplication by `r : R`. Use `•` instead. -/
-def smul' (r : R) : Sym[R]^n M →+ Sym[R]^n M :=
+def smul' (r : R) : Sym[R] ι M →+ Sym[R] ι M :=
   AddCon.lift _ (AddMonoidHom.comp (AddCon.mk' _) {
       toFun := (r • ·)
       map_zero' := smul_zero r
       map_add' := smul_add r })
     (fun x y h ↦ Quotient.sound (smul r x y h))
 
-instance module : Module R (Sym[R]^n M) where
-  smul r x := smul' M n r x
+instance module : Module R (Sym[R] ι M) where
+  smul r x := smul' ι M r x
   one_smul x := AddCon.induction_on x <| fun x ↦ congr_arg _ <| one_smul R x
   mul_smul r s x := AddCon.induction_on x <| fun x ↦ congr_arg _ <| mul_smul r s x
   smul_zero r := congr_arg _ <| smul_zero r
@@ -91,37 +99,37 @@ instance module : Module R (Sym[R]^n M) where
   add_smul r s x := AddCon.induction_on x <| fun x ↦ congr_arg _ <| add_smul r s x
   zero_smul x := AddCon.induction_on x <| fun x ↦ congr_arg _ <| zero_smul R x
 
-/-- The canonical map from the `n`ᵗʰ tensor power to the `n`ᵗʰ symmetric tensor power. -/
-def mk : ⨂[R]^n M →ₗ[R] Sym[R]^n M where
+/-- The canonical map from the `ι`-indexed tensor power to the symmetric tensor power. -/
+def mk : (⨂[R] (_ : ι), M) →ₗ[R] Sym[R] ι M where
   map_smul' _ _ := rfl
   __ := AddCon.mk' _
 
-variable {M n} in
-/-- The multilinear map that takes `n` elements of `M` and returns their symmetric tensor product.
-Denoted `⨂ₛ[R] i, f i`. -/
-def tprod : MultilinearMap R (fun _ : Fin n ↦ M) Sym[R]^n M :=
-  (mk R M n).compMultilinearMap (PiTensorProduct.tprod R)
+variable {M ι} in
+/-- The multilinear map that takes `ι`-indexed elements of `M` and
+returns their symmetric tensor power. Denoted `⨂ₛ[R] i, f i`. -/
+def tprod : MultilinearMap R (fun _ : ι ↦ M) Sym[R] ι M :=
+  (mk R ι M).compMultilinearMap (PiTensorProduct.tprod R)
 
 unsuppress_compilation in
 @[inherit_doc tprod]
 notation3:100 "⨂ₛ["R"] "(...)", "r:(scoped f => tprod R f) => r
 
-variable {R M n} in
-@[simp] lemma tprod_equiv (e : Perm (Fin n)) (f : Fin n → M) :
+variable {R ι M} in
+@[simp] lemma tprod_equiv (e : Perm ι) (f : ι → M) :
     (⨂ₛ[R] i, f (e i)) = ⨂ₛ[R] i, f i :=
   Eq.symm <| Quot.sound <| AddConGen.Rel.of _ _ <| Rel.perm e f
 
 variable {R M n} in
-@[simp] lemma domDomCongr_tprod (e : Perm (Fin n)) :
-    (tprod R (M := M) (n := n)).domDomCongr e = tprod R :=
+@[simp] lemma domDomCongr_tprod (e : Perm ι) :
+    (tprod R (ι := ι) (M := M)).domDomCongr e = tprod R :=
   MultilinearMap.ext <| tprod_equiv e
 
-theorem range_mk : LinearMap.range (mk R M n) = ⊤ :=
+theorem range_mk : LinearMap.range (mk R ι M) = ⊤ :=
   LinearMap.range_eq_top_of_surjective _ AddCon.mk'_surjective
 
 /-- The pure tensors (i.e. the elements of the image of `SymmetricPower.tprod`) span the symmetric
-tensor product. -/
-theorem span_tprod_eq_top : Submodule.span R (Set.range (tprod R (M := M) (n := n))) = ⊤ := by
+tensor power. -/
+theorem span_tprod_eq_top : Submodule.span R (Set.range (tprod R (ι := ι) (M := M))) = ⊤ := by
   rw [tprod, LinearMap.coe_compMultilinearMap, Set.range_comp, Submodule.span_image,
     PiTensorProduct.span_tprod_eq_top, Submodule.map_top, range_mk]
 


### PR DESCRIPTION
This adapts leanprover/mathlib4#26192 to use a general indexing type as suggested in review. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

Take it or leave it as you wish. 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
