### PR TITLE
feat(NamePolyVars): no space

### DIFF
--- a/Mathlib/Tactic/Ring/NamePolyVars.lean
+++ b/Mathlib/Tactic/Ring/NamePolyVars.lean
@@ -17,8 +17,8 @@ Usage:
 ```lean
 variable (R : Type) [CommRing R]
 
-name_poly_vars R [X,Y,Z]
-name_poly_vars R [s][t][u]
+name_poly_vars R[X,Y,Z]
+name_poly_vars R[s][t][u]
 
 #check Y -- Y : MvPolynomial (Fin 3) R
 #check t -- t : Polynomial (Polynomial (Polynomial R))
@@ -30,45 +30,61 @@ open Lean Elab Command
 namespace Mathlib.Tactic
 
 /--
+A variable that can be in the head position of a `name_poly_vars` command.
+This is either an identifier or a term enclosed in parentheses.
+-/
+syntax polyVarsHead := ident <|> ("(" term ")")
+
+/--
+Convert a `polyVarsHead` to a term.
+-/
+def polyVarsHeadToTerm? (stx : TSyntax ``polyVarsHead) : Option Term :=
+  match stx with
+  | `(polyVarsHead| $k:ident) => some { raw := k.raw }
+  | `(polyVarsHead| ($u:term)) => some u
+  | _ => none
+
+/--
 The command `name_poly_vars` names variables in
 `MvPolynomial (Fin n) R` for the appropriate value of `n`.
 The notation introduced by this command is local.
 
-For `Polynomial (Polynomial (...))`, use the syntax `name_poly_vars R [X][Y][Z]`.
+For `Polynomial (Polynomial (...))`, use the syntax `name_poly_vars R[X][Y][Z]`.
 
 Usage:
 
 ```lean
 variable (R : Type) [CommRing R]
 
-name_poly_vars R [X,Y,Z]
+name_poly_vars R[X,Y,Z]
 
 #check Y -- Y : MvPolynomial (Fin 3) R
 ```
 -/
-syntax (name := nameMvPolyVars) "name_poly_vars " term:max ppSpace "[" ident,+ "]" : command
+syntax (name := nameMvPolyVars) "name_poly_vars " polyVarsHead "[" ident,+ "]" : command
 
 /--
 The command `name_poly_vars` names variables in `Polynomial (Polynomial (... R))` stacked
 appropriately many times. The notation introduced by this command is local.
 
-For `MvPolynomial (Fin n) R`, use the syntax `name_poly_vars R [X,Y,Z]`.
+For `MvPolynomial (Fin n) R`, use the syntax `name_poly_vars R[X,Y,Z]`.
 
 Usage:
 
 ```lean
 variable (R : Type) [CommRing R]
 
-name_poly_vars R [X][Y][Z]
+name_poly_vars R[X][Y][Z]
 
 #check Y -- Y : Polynomial (Polynomial (Polynomial R))
 ```
 -/
-syntax (name := namePolyVars) "name_poly_vars " term:max "[" sepBy(ident, "][") "]" : command
+syntax (name := namePolyVars) "name_poly_vars " polyVarsHead "[" sepBy(ident, "][") "]" : command
 
 @[command_elab nameMvPolyVars, inherit_doc namePolyVars]
 def elabNameMvVariables : CommandElab
-| `(command|name_poly_vars $R:term [$vars:ident,*]) => do
+| `(command|name_poly_vars $R:polyVarsHead [$vars:ident,*]) => do
+  let some R := polyVarsHeadToTerm? R | throwUnsupportedSyntax
   let vars := vars.getElems
   let size := vars.size
   let sizeStx : TSyntax `term := quote size
@@ -83,7 +99,8 @@ def elabNameMvVariables : CommandElab
 
 @[command_elab namePolyVars, inherit_doc namePolyVars]
 def elabNamePolyVariables : CommandElab
-| `(command|name_poly_vars $R:term [$vars:ident][*]) => do
+| `(command|name_poly_vars $R:polyVarsHead [$vars:ident][*]) => do
+  let some R := polyVarsHeadToTerm? R | throwUnsupportedSyntax
   let vars := vars.getElems.reverse
   let size := vars.size
   let type : Term ← size.rec (return R) fun _ S ↦ do

--- a/MathlibTest/NamePolyVars.lean
+++ b/MathlibTest/NamePolyVars.lean
@@ -3,10 +3,10 @@ import Mathlib.Tactic.Ring.NamePolyVars
 
 variable (R : Type) [CommRing R]
 
-name_poly_vars R [X,Y,Z]
-name_poly_vars Int [q]
-name_poly_vars R [S][T][U]
-name_poly_vars (ZMod 37) [d,e]
+name_poly_vars R[X,Y,Z]
+name_poly_vars Int[q]
+name_poly_vars R[S][T][U]
+name_poly_vars (ZMod 37)[d,e]
 
 noncomputable example : Vector (MvPolynomial (Fin 3) R) 3 :=
   have : X = MvPolynomial.X 0 := rfl


### PR DESCRIPTION
Remove that annoying space.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
