### PR TITLE
more cleanup

### DIFF
--- a/Mathlib/Tactic/Ring/NamePolyVars.lean
+++ b/Mathlib/Tactic/Ring/NamePolyVars.lean
@@ -92,9 +92,9 @@ syntax poly_idents := sepBy(ident, ",", ",", allowTrailingSep)
 
 /-- Parse `poly_idents` into either a single identifier or an array of identifiers. -/
 def parsePolyIdents : TSyntax ``poly_idents → Option (String ⊕ Array String)
-  | `(poly_idents| $v:ident) => pure (Sum.inl v.getId.toString)
-  | `(poly_idents| $vs:ident,*) => pure (Sum.inr (vs.getElems.map fun v ↦ v.getId.toString))
-  | _ => .none
+  | `(poly_idents| $v:ident) => some (.inl v.getId.toString)
+  | `(poly_idents| $vs:ident,*) => some (.inr (vs.getElems.map fun v ↦ v.getId.toString))
+  | _ => none
 
 -- An unambiguously bracketed term, which is `_`, an identifier, or a term enclosed in brackets.
 -- This has no doc-string because that would show up in hover information.
@@ -158,14 +158,13 @@ syntax poly_var : term
 
 /-- A parsed body for one polynomial-like notation, consisting of the type of the notation
 (e.g. `MvPolynomial`) and the array of variable identifiers (or one identifier). -/
-structure Body : Type where
-  /-- The signature of the notation, which consists of the opening and closing brackets,
-  and whether the notation is multivariable. -/
-  signature : NotationSignature
-  /-- The main notation, which consists of the type, constant, and variable parts. -/
-  main : Notation
-  /-- The names for the variables. -/
+structure DeclaredNotationPart extends Notation where
+  /-- The declared names for the variables. -/
   vars : (String ⊕ Array String)
+  /-- The opening bracket -/
+  openingStx : TSyntax `poly_opening
+  /-- The closing bracket -/
+  closingStx : TSyntax `poly_closing
 
 /-- The syntax for using a declared polynomial-like notation, e.g. `[x,y]` or `[[t]]`, which uses
 `poly_var` instead of `ident`. -/
@@ -175,36 +174,36 @@ syntax polyesque_notation := atomic(poly_opening poly_vars poly_closing)
 `ident` instead of `poly_var`. -/
 syntax polyesque_notation_input := atomic(poly_opening poly_idents poly_closing)
 
-/-- Parse a `polyesque_notation_input` into its `Body`, `poly_opening`, and `poly_closing`. -/
+/-- Parse a `polyesque_notation_input` into a `DeclaredNotationPart`. -/
 def parsePolyesqueNotationInput (p : TSyntax ``polyesque_notation_input) :
-    CommandElabM (Body × TSyntax `poly_opening × TSyntax `poly_closing) := do
-  let `(polyesque_notation_input| $opening:poly_opening $v:poly_idents $closing:poly_closing) := p
+    CommandElabM DeclaredNotationPart := do
+  let `(polyesque_notation_input| $openingStx $v $closingStx) := p
     | throwError m!"Unrecognised polynomial-like notation: {p}"
-  have openingS := parseBracket opening
-  have closingS := parseBracket closing
+  have opening := parseBracket openingStx
+  have closing := parseBracket closingStx
   let some vars := parsePolyIdents v
     | throwError m!"Unrecognised variable notation: {v}"
   have mv? : Bool := vars.isRight
-  let some n := (notationTableExt.getState (← getEnv)).get? ⟨openingS, closingS, mv?⟩
-    | throwError s!"Unrecognised polynomial-like syntax: (mv := {mv?}) {opening} {closing}"
-  return (⟨⟨openingS, closingS, mv?⟩, n, vars⟩, opening, closing)
+  let some n := (notationTableExt.getState (← getEnv)).get? { opening, closing, mv? }
+    | throwError s!"Unrecognised polynomial-like syntax: (mv := {mv?}) {openingStx} {closingStx}"
+  return { n with vars, openingStx, closingStx }
 
 /-- Create the type for a polynomial-like notation, e.g. `[a,b]` gives `MvPolynomial (Fin 2) R`,
 where `R` is the previous type. -/
-def Body.mkType (b : Body) (type : Term) : CommandElabM Term :=
-  match b.vars with
-  | Sum.inl _ => `($b.main.type $type)
-  | Sum.inr ns => do `($b.main.type $(← `(Fin $(quote ns.size))) $type)
+def DeclaredNotationPart.mkType (d : DeclaredNotationPart) (type : Term) : CommandElabM Term :=
+  match d.vars with
+  | .inl _ => `($d.type $type)
+  | .inr ns => do `($d.type $(← `(Fin $(quote ns.size))) $type)
 
 /-- Create the constant term for a polynomial-like notation. -/
-def Body.mkC (b : Body) (term : Term) : CommandElabM Term :=
-  `($b.main.c $term)
+def DeclaredNotationPart.mkC (d : DeclaredNotationPart) (term : Term) : CommandElabM Term :=
+  `($d.c $term)
 
 /-- Create the formal variable term(s) for a polynomial-like notation. -/
-def Body.mkX (b : Body) : CommandElabM (Array (String × Term)) :=
-  match b.vars with
-  | Sum.inl n => return #[(n, b.main.x)]
-  | Sum.inr ns => ns.zipIdx.mapM fun n ↦ return (n.fst, ← `($b.main.x $(quote n.snd)))
+def DeclaredNotationPart.mkX (d : DeclaredNotationPart) : CommandElabM (Array (String × Term)) :=
+  match d.vars with
+  | .inl n => return #[(n, d.x)]
+  | .inr ns => ns.zipIdx.mapM fun (n, i) ↦ return (n, ← `($d.x $(quote i)))
 
 /-- The syntax for polynomial-like notations, which is an unambiguous term declaration followed by
 one or more polynomial-like notations, e.g. `(Fin 37)[x,y,z][[t]]`. -/
@@ -214,32 +213,32 @@ syntax polyesque := term_decl (noWs polyesque_notation)+
 syntax:max polyesque : term
 
 /-- Dynamically build the syntax for a declared polynomial-like notation. -/
-def mkBracketStx (opening : TSyntax `poly_opening) (closing : TSyntax `poly_closing) (mv? : Bool)
-    (polyVars : Array (TSyntax `poly_var)) : CommandElabM (TSyntax ``polyesque_notation) := do
-  let vars ← match mv?, polyVars with
-    | true, #[v] => `(poly_vars| $v,)
+def mkBracketStx (d : DeclaredNotationPart) (polyVars : Array (TSyntax `poly_var)) :
+    CommandElabM (TSyntax ``polyesque_notation) := do
+  let vars ← match d.vars, polyVars with
+    | .inr _, #[v] => `(poly_vars| $v,)
     | _, _ => `(poly_vars| $(Syntax.TSepArray.ofElems polyVars):poly_var,*)
-  `(polyesque_notation| $opening$vars$closing)
+  `(polyesque_notation| $d.openingStx$vars$d.closingStx)
 
 /-- Given one segment (e.g. `[x,y]`) of the declaration, extract all the relevant information:
 the relevant functor (`MvPolynomial (Fin 2)`), the formal variables, and their meanings. Then,
 register the variables (`x` and `y`) as polynomial variables (`poly_var`). -/
 def processAndDeclarePolyesqueNotationInput (p : TSyntax ``polyesque_notation_input)
-    (terms : Array (TSyntax `poly_var × Term)) (oldFunctor : Term → CommandElabM Term) :
+    (oldTerms : Array (TSyntax `poly_var × Term)) (oldFunctor : Term → CommandElabM Term) :
     CommandElabM (TSyntax ``polyesque_notation × Array (TSyntax `poly_var × Term) ×
       (Term → CommandElabM Term) × Term) := do
-  let (b, opening, closing) ← parsePolyesqueNotationInput p
-  let newTerms : Array (TSyntax `poly_var × Term) ← (← b.mkX).mapM fun (s, t) ↦ do
+  let d ← parsePolyesqueNotationInput p
+  let newTerms ← (← d.mkX).mapM fun (s, t) ↦ do
     -- Declares the new formal variables as `poly_var`.
     let kind ← elabSyntax <| ← `(command| local syntax $(quote s):str : poly_var)
     return (⟨mkNode kind #[mkAtom s]⟩, t)
-  let bracketStx ← mkBracketStx opening closing b.1.mv? (newTerms.map (·.1))
-  let terms ← terms.mapM fun (v, t) ↦ return (v, ← b.mkC t)
-  let newFunctor := oldFunctor >=> b.mkType
-  return (bracketStx, terms ++ newTerms, newFunctor, b.main.type)
+  let bracketStx ← mkBracketStx d (newTerms.map (·.1))
+  let oldTerms ← oldTerms.mapM fun (v, t) ↦ return (v, ← d.mkC t)
+  let newFunctor := oldFunctor >=> d.mkType
+  return (bracketStx, oldTerms ++ newTerms, newFunctor, d.type)
 
 /-- A helper function to elaborate macro rules and trace their declarations. -/
-def elabMacroRulesAndTrace (p : TSyntax ``polyesque) (t : Term) : CommandElabM Unit := do
+def elabPolyesqueMacroRules (p : TSyntax ``polyesque) (t : Term) : CommandElabM Unit := do
   trace[name_poly_vars] m!"Declaring polynomial-like notation: {p}\nResult: {t}"
   elabCommand <| ← `(command| local macro_rules | `($p:polyesque) => `($t))
 
@@ -260,24 +259,24 @@ name_poly_vars _[a,b,c,d]
 -/
 elab "name_poly_vars " head:term_decl body:(noWs polyesque_notation_input)+ : command => do
   let mut terms : Array (TSyntax `poly_var × Term) := #[]
-  let mut bodyVar : Array (TSyntax ``polyesque_notation) := #[]
+  let mut bodyStxs : Array (TSyntax ``polyesque_notation) := #[]
   let mut functor : Term → CommandElabM Term := pure
   let mut lastHead : Term := default
   for p in body do
     let processed ← processAndDeclarePolyesqueNotationInput p terms functor
     (terms, functor, lastHead) := processed.2
-    bodyVar := bodyVar.push processed.1
-  have body := Syntax.TSepArray.ofElems (sep := "") bodyVar
+    bodyStxs := bodyStxs.push processed.1
+  have bodyStx := Syntax.TSepArray.ofElems (sep := "") bodyStxs
   let typeIdent ← functor (← `($$i:ident))
-  let polyesqueIdent ← `(polyesque| $$i:ident$body:polyesque_notation*)
+  let polyesqueIdent ← `(polyesque| $$i:ident$bodyStx:polyesque_notation*)
   let typeTerm ← functor (← `($$t:term))
-  let polyesqueTerm ← `(polyesque| ($$t:term)$body:polyesque_notation*)
+  let polyesqueTerm ← `(polyesque| ($$t:term)$bodyStx:polyesque_notation*)
   let type : Term := ← match head with
   | `(term_decl| $_:hole) => do
-    elabMacroRulesAndTrace (← `(polyesque| $$h:hole$body:polyesque_notation*))
+    elabPolyesqueMacroRules (← `(polyesque| $$h:hole$bodyStx:polyesque_notation*))
       (← functor (← `($$h:hole)))
-    elabMacroRulesAndTrace polyesqueIdent typeIdent
-    elabMacroRulesAndTrace polyesqueTerm typeTerm
+    elabPolyesqueMacroRules polyesqueIdent typeIdent
+    elabPolyesqueMacroRules polyesqueTerm typeTerm
     -- if the head of the term is a constant, then deploy the unexpander.
     if let `($c:ident) := lastHead then
       trace[name_poly_vars] m!"Declaring unexpander for {c}"
@@ -290,8 +289,8 @@ elab "name_poly_vars " head:term_decl body:(noWs polyesque_notation_input)+ : co
     functor (← `(_))
   | _ => do
     let type ← functor (termDeclToTerm head)
-    let polyesque ← `(polyesque| $head$body:polyesque_notation*)
-    elabMacroRulesAndTrace polyesque type
+    let polyesque ← `(polyesque| $head$bodyStx:polyesque_notation*)
+    elabPolyesqueMacroRules polyesque type
     -- if the head of the term is a constant, then deploy the unexpander.
     if let `($c:ident) := lastHead then
       trace[name_poly_vars] m!"Declaring unexpander for {c}"
@@ -322,7 +321,7 @@ elab "name_poly_vars " head:term_decl body:(noWs polyesque_notation_input)+ : co
     let some (keys, matcher) ←
       runTermElabM fun _ => (Notation3.mkExprMatcher val #[]).run | continue
     for key in keys do
-      let bodyCore ← `($matcher Notation3.MatchState.empty >>= fun _ => `($v:poly_var))
+      let bodyCore ← `($matcher Notation3.MatchState.empty *> `($v:poly_var))
       let body ← match key with
         | .app _ arity => `(withOverApp $(quote arity) $bodyCore)
         | _            => pure bodyCore

--- a/MathlibTest/NamePolyVars.lean
+++ b/MathlibTest/NamePolyVars.lean
@@ -1,4 +1,3 @@
--- import Mathlib.Tactic.Linter.Lint
 import Mathlib.Tactic.Ring.NamePolyVars
 
 -- set_option trace.name_poly_vars true
@@ -138,5 +137,21 @@ name_poly_vars (Fin 37)[x,y,z][C]
 /-- info: (Fin 37)[x,y,z][C] : Type -/
 #guard_msgs in
 #check (Fin 37)[x,y,z][C]
+
+/-- info: x : (Fin 37)[x,y,z][C] -/
+#guard_msgs in
+#check x
+
+/-- info: y : (Fin 37)[x,y,z][C] -/
+#guard_msgs in
+#check y
+
+/-- info: z : (Fin 37)[x,y,z][C] -/
+#guard_msgs in
+#check z
+
+/-- info: C : (Fin 37)[x,y,z][C] -/
+#guard_msgs in
+#check C
 
 end Test4


### PR DESCRIPTION
I refactored the structure `Body`, giving it a new name. I also changed the names of some other things to be easier to understand.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

For details on the "pull request lifecycle" in mathlib, please see:
https://leanprover-community.github.io/contribute/index.html

In particular, note that most reviewers will only notice your PR
if it passes the continuous integration checks.
Please ask for help on https://leanprover.zulipchat.com if needed.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

If you are moving or deleting declarations, please include these lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Moves:
- Vector.* -> List.Vector.*
- ...

Deletions:
- Nat.bit1_add_bit1
- ...

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
